### PR TITLE
Add basic PIT channel 1 latch/read test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 codex
+pit_test
 *.o

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,12 @@ codex: $(SRC) include/codex_core.h
 	$(CC) $(CFLAGS) $(SRC) -Iinclude -o $@ $(LDFLAGS) $(LIBS)
 
 clean:
-	rm -f codex
+	rm -f codex pit_test
 
-.PHONY: clean
+pit_test: src/codex_pit.c tests/pit_test.c include/codex_pit.h
+	$(CC) $(CFLAGS) -Iinclude src/codex_pit.c tests/pit_test.c -o $@
+
+test: pit_test
+	./pit_test
+
+.PHONY: clean test pit_test

--- a/tests/pit_test.c
+++ b/tests/pit_test.c
@@ -1,0 +1,43 @@
+#include <assert.h>
+#include <stdio.h>
+#include "codex_pit.h"
+
+// Stub to satisfy linkage; actual implementation isn't needed for these tests.
+struct CodexPic;
+struct CodexCore;
+void codex_pic_pulse_irq(struct CodexPic* pic, struct CodexCore* core, int line) {
+    (void)pic; (void)core; (void)line;
+}
+
+int main(void) {
+    CodexPit pit;
+    codex_pit_init(&pit);
+
+    // Program channel 1 with reload value 0x7474 (mode 2, LSB+MSB)
+    codex_pit_io_write(&pit, 0x43, 0x74);
+    codex_pit_io_write(&pit, 0x41, 0x74); // LSB
+    codex_pit_io_write(&pit, 0x41, 0x74); // MSB
+
+    assert(pit.ch1_rw == 3);              // LSB+MSB mode set
+    assert(pit.ch1_reload == 0x7474);     // reload correctly formed
+
+    uint16_t expected[] = {0x7469, 0x7425, 0x73E5, 0x73A4, 0x7366};
+    size_t count = sizeof(expected)/sizeof(expected[0]);
+
+    for (size_t i = 0; i < count; ++i) {
+        codex_pit_io_write(&pit, 0x43, 0x40); // latch command for ch1
+        pit.ch1_latch = expected[i];          // emulate timer value after latch
+        pit.ch1_latched = 1;
+        pit.ch1_flip = 0;
+
+        uint8_t lsb = codex_pit_io_read(&pit, 0x41);
+        uint8_t msb = codex_pit_io_read(&pit, 0x41);
+
+        assert(lsb == (expected[i] & 0xFF));
+        assert(msb == (expected[i] >> 8));
+        assert(pit.ch1_latched == 0); // latch cleared after MSB read
+    }
+
+    printf("PIT channel 1 latch/read test passed\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add a unit test exercising PIT channel 1 programming and latch reads
- wire test into Makefile and ignore the generated binary

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68986dbd0474832ca45b48ff132e65a7